### PR TITLE
add support for filter 'marked'

### DIFF
--- a/grammars/jade.cson
+++ b/grammars/jade.cson
@@ -29,7 +29,7 @@
     'name': 'comment.block.jade'
   }
   {
-    'begin': '^(\\s*)(\\:markdown)'
+    'begin': '^(\\s*)(\\:mark(down|ed))'
     'beginCaptures':
       '2':
         'name': 'entity.name.function.jade'


### PR DESCRIPTION
`:marked` will be replacing `:markdown` in future versions of jade. Added support for this.
